### PR TITLE
chore: restrict updating to docs-staging-v2

### DIFF
--- a/.kokoro/docs/common.cfg
+++ b/.kokoro/docs/common.cfg
@@ -30,7 +30,7 @@ env_vars: {
 
 env_vars: {
     key: "V2_STAGING_BUCKET"
-    value: "docs-staging-v2"
+    value: "docs-staging-v2-staging"
 }
 
 # It will upload the docker image after successful builds.

--- a/.kokoro/docs/common.cfg
+++ b/.kokoro/docs/common.cfg
@@ -30,7 +30,7 @@ env_vars: {
 
 env_vars: {
     key: "V2_STAGING_BUCKET"
-    value: "docs-staging-v2-staging"
+    value: "docs-staging-v2"
 }
 
 # It will upload the docker image after successful builds.

--- a/owlbot.py
+++ b/owlbot.py
@@ -36,8 +36,8 @@ excludes=[
 s.move(templated_files, excludes=excludes)
 
 # Redirect publishing to the staging branch for Cloud RAD to avoid making this public.
-# Producing the output helps verify that content gets generated but will not affect rest of the
-# existing pipeline.
+# Moving to staging and still producing the output helps verify that content gets 
+# generated but will not affect rest of the existing pipeline.
 s.replace(
     ".kokoro/docs/common.cfg",
     r'value: "docs-staging-v2"',

--- a/owlbot.py
+++ b/owlbot.py
@@ -30,7 +30,10 @@ s.remove_staging_dirs()
 
 templated_files = common.py_library(microgenerator=True)
 
-excludes=[".coveragerc"]
+excludes=[
+    ".coveragerc",
+    ".kokoro/docs/*"
+]
 s.move(templated_files, excludes=excludes)
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)

--- a/owlbot.py
+++ b/owlbot.py
@@ -31,9 +31,17 @@ s.remove_staging_dirs()
 templated_files = common.py_library(microgenerator=True)
 
 excludes=[
-    ".coveragerc",
-    ".kokoro/docs/*"
+    ".coveragerc"
 ]
 s.move(templated_files, excludes=excludes)
+
+# Redirect publishing to the staging branch for Cloud RAD to avoid making this public.
+# Producing the output helps verify that content gets generated but will not affect rest of the
+# existing pipeline.
+s.replace(
+    ".kokoro/docs/common.cfg",
+    r'value: "docs-staging-v2"',
+    r'value: "docs-staging-v2-staging"'
+)
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)


### PR DESCRIPTION
While this repo is still private, could you restrict docfx from uploading to `docs-staging-v2` and instead redirect it to `docs-staging-v2-staging`?