### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "resourcesettings",
     "name_pretty": "Resource Settings",
     "product_documentation": "https://cloud.google.com/resource-settings",
-    "client_documentation": "https://googleapis.dev/python/resourcesettings/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/resourcesettings/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ across the Cloud Resource Hierarchy.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-resource-settings.svg
    :target: https://pypi.org/project/google-cloud-resource-settings/
 .. _Resource Settings: https://cloud.google.com/resource-settings
-.. _Client Library Documentation: https://googleapis.dev/python/resourcesettings/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/resourcesettings/latest
 .. _Product Documentation:  https://cloud.google.com/resource-manager/docs/resource-settings/overview
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.